### PR TITLE
fix(dual_camera): Fix build for IDF 6.0

### DIFF
--- a/host/camera_display/README.md
+++ b/host/camera_display/README.md
@@ -6,9 +6,9 @@
 ## Overview
 
 This demo is using a following (sub)components:
-- [USB Host stack](https://github.com/espressif/esp-idf/tree/master/components/usb)
+- [USB Host stack](https://github.com/espressif/esp-usb)
 - [USB UVC driver](https://github.com/espressif/esp-usb/tree/master/host/class/uvc/usb_host_uvc)
-- [External USB Hub driver](https://github.com/espressif/esp-idf/tree/master/components/usb)
+- [External USB Hub driver](https://github.com/espressif/esp-usb)
 - [Hardware JPEG Decoder](https://github.com/espressif/esp-idf/tree/master/components/esp_driver_jpeg)
 - [PPA (Per Pixel Accelerator)](https://github.com/espressif/esp-idf/tree/master/components/esp_driver_ppa)
 - [LCD Display driver](https://github.com/espressif/esp-iot-solution/tree/master/components/display/lcd/esp_lcd_ek79007)
@@ -27,7 +27,7 @@ Up to 2 USB Cameras, connected via an external USB hub into a HS USB port of [ES
 
 User can interact with the demo using console.
 
-```
+```shell
 esp32p4> help
 help  [<string>] [-v <0|1>]
   Print the summary of all registered commands if no arguments are given,
@@ -43,7 +43,7 @@ stream  [-S <stream_id>] [-T <stream_id>]
 
 User can start or stop a specific video stream
 
-```
+```shell
 esp32p4> stream -T 0
 I (92728) esp-usb-demo: Console: stream stop
 I (92828) esp-usb-demo: Stream 0 stopped
@@ -75,7 +75,7 @@ Camera resolution in both modes are selected in respect to the [ESP32-P4-Functio
 
 Below is a sample output of the demo, with an external USB Hub and both USB cameras already connected to the `esp32p4` HS USB port. The USB cameras are then unplugged and plugged back in.
 
-```
+```shell
 I (1316) main_task: Started on CPU0
 I (1326) esp_psram: Reserving pool of 32K of internal memory for DMA/internal allocations
 I (1326) main_task: Calling app_main()
@@ -128,7 +128,7 @@ I (10846) esp-usb-demo: Device suddenly disconnected
 I (10846) esp-usb-demo: UVC Device disconnected -> Close the UVC stream
 ...
 
-FIrst camera connected to external USB Hub
+First camera connected to external USB Hub
 
 ...
 I (14196) esp-usb-demo: UVC Device connected -> Open the UVC stream
@@ -150,3 +150,16 @@ I (18016) esp-usb-demo: Stream opened, streaming...
 I (18016) esp-usb-demo: UVC device opened, opening stream
 I (18026) esp-usb-demo: Setting resolution to half
 I (18066) esp-usb-demo: Stream opened, streaming...
+```
+
+## Hardware needed
+
+- [ESP32-P4-Function-EV-Board](https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32p4/esp32-p4-function-ev-board/index.html)
+- Up-to 2 USB cameras (cameras resolutions shall be configured using `idf.py menuconfig` before running the demo)
+- external usb hub
+
+## Set-up of the demo
+
+- Connect the external hub to the [ESP32-P4-Function-EV-Board's](https://docs.espressif.com/projects/esp-dev-kits/en/latest/esp32p4/esp32-p4-function-ev-board/index.html) HS USB Host port
+- Connect a single, or both USB Cameras to the external hub
+- Flash and run the demo

--- a/host/camera_display/main/CMakeLists.txt
+++ b/host/camera_display/main/CMakeLists.txt
@@ -1,4 +1,4 @@
 idf_component_register(SRCS "main.c" "ek97009_init.c"
                        INCLUDE_DIRS "include"
-                       PRIV_REQUIRES usb fatfs esp_driver_gpio esp_timer esp_psram console esp_lcd esp_driver_jpeg esp_driver_ppa
+                       PRIV_REQUIRES usb fatfs esp_driver_gpio esp_timer esp_psram console esp_lcd esp_driver_jpeg esp_driver_ppa esp_driver_ledc
                        )

--- a/host/camera_display/main/ek97009_init.c
+++ b/host/camera_display/main/ek97009_init.c
@@ -5,6 +5,7 @@
  */
 
 #include "sdkconfig.h"
+#include "esp_heap_caps.h"
 #include "driver/ledc.h"
 #include "esp_err.h"
 #include "esp_log.h"
@@ -134,7 +135,11 @@ esp_err_t bsp_display_new_with_handles(const bsp_display_config_t *config, bsp_l
     esp_lcd_dsi_bus_config_t bus_config = {
         .bus_id = 0,
         .num_data_lanes = BSP_LCD_MIPI_DSI_LANE_NUM,
-        .phy_clk_src = MIPI_DSI_PHY_CLK_SRC_DEFAULT,
+#if CONFIG_ESP32P4_REV_MIN_FULL >= 300
+        .phy_clk_src = MIPI_DSI_PHY_PLLREF_CLK_SRC_DEFAULT,
+#else
+        .phy_clk_src = MIPI_DSI_PHY_PLLREF_CLK_SRC_DEFAULT_LEGACY,
+#endif
         .lane_bit_rate_mbps = BSP_LCD_MIPI_DSI_LANE_BITRATE_MBPS,
     };
     ESP_RETURN_ON_ERROR(esp_lcd_new_dsi_bus(&bus_config, &mipi_dsi_bus), TAG, "New DSI bus init failed");
@@ -151,7 +156,7 @@ esp_err_t bsp_display_new_with_handles(const bsp_display_config_t *config, bsp_l
     // create EK79007 control panel
     ESP_LOGI(TAG, "Install EK79007 LCD control panel");
 
-    esp_lcd_dpi_panel_config_t dpi_config = EK79007_1024_600_PANEL_60HZ_CONFIG(LCD_COLOR_PIXEL_FORMAT_RGB565);
+    esp_lcd_dpi_panel_config_t dpi_config = EK79007_1024_600_PANEL_60HZ_CONFIG_CF(LCD_COLOR_FMT_RGB565);
     dpi_config.num_fbs = CONFIG_BSP_LCD_DPI_BUFFER_NUMS;
 
     ek79007_vendor_config_t vendor_config = {

--- a/host/camera_display/main/idf_component.yml
+++ b/host/camera_display/main/idf_component.yml
@@ -1,5 +1,5 @@
 ## IDF Component Manager Manifest File
 dependencies:
-  idf: ">=5.5"
+  idf: ">=6.0"
   usb_host_uvc: ">=2.0"
-  esp_lcd_ek79007: "1.*"
+  esp_lcd_ek79007: ">=2.0.1"

--- a/host/camera_display/main/include/display.h
+++ b/host/camera_display/main/include/display.h
@@ -24,7 +24,7 @@
 #define ESP_LCD_COLOR_FORMAT_RGB565    (1)
 #define ESP_LCD_COLOR_FORMAT_RGB888    (2)
 
-#define BSP_LCD_COLOR_SPACE         (ESP_LCD_COLOR_SPACE_RGB)
+#define BSP_LCD_COLOR_SPACE         (LCD_RGB_ELEMENT_ORDER_RGB)
 
 /* LCD display definition 1024x600 */
 #define BSP_LCD_H_RES              (1024)


### PR DESCRIPTION
## Summary

- Fixing build of the demo for IDF 6.0
- Also build for esp32p4 v3
- Updating README with some information about how to setup and run the demo

## Related

- waiting for the `esp_lcd_ek79007` release (version `2.1`) to fix build errors